### PR TITLE
Add explicit border color to the container styles

### DIFF
--- a/src/components/container/style.css
+++ b/src/components/container/style.css
@@ -12,7 +12,7 @@
 			@apply
 			nfd-p-8
 			nfd-border-b
-			nfd-border-line
+			nfd-border-[#E2E8F0]
 			nfd-flex
 			nfd-flex-col
 			nfd-gap-4


### PR DESCRIPTION
This will fix an issue in environments where `nfd-border-line` is not defined in the tailwind config.

* it's not currently causing any issues in any consuming brand plugins since they all have that class defined, so this doesn't require an immediate release.