### PR TITLE
added reset type to fix console warning

### DIFF
--- a/src/elements/button/index.js
+++ b/src/elements/button/index.js
@@ -63,7 +63,7 @@ const Button = forwardRef( ( {
 const propTypes = {
 	children: PropTypes.node.isRequired,
 	as: PropTypes.elementType,
-	type: PropTypes.oneOf( [ "button", "submit" ] ),
+	type: PropTypes.oneOf( [ "button", "submit", "reset" ] ),
 	variant: PropTypes.oneOf( keys( classNameMap.variant ) ),
 	size: PropTypes.oneOf( keys( classNameMap.size ) ),
 	isLoading: PropTypes.bool,


### PR DESCRIPTION
added type `reset` to button types to fix console warning.

<img width="1170" alt="Screenshot 2024-03-04 at 4 43 42 PM" src="https://github.com/newfold-labs/npm-ui-component-library/assets/80672694/9210192e-3ecd-46d1-81e1-4b58891da81e">
