### PR TITLE
Fix label elements when dangerouslySetInnerHTML is passed

### DIFF
--- a/src/elements/label/index.js
+++ b/src/elements/label/index.js
@@ -17,16 +17,27 @@ const Label = forwardRef( ( {
 	requiredIndicator,
 	children,
 	...props
-}, ref ) => (
-	<Component
-		ref={ ref }
-		className={ classNames( "nfd-label", className ) }
-		{ ...props }
-	>
-		{ label || children || null }
-		{ requiredIndicator && <span className="nfd-label__required">*</span> }
-	</Component>
-) );
+}, ref ) => {
+
+	const hasDangerouslySetInnerHTML = !! props?.dangerouslySetInnerHTML?.__html;
+
+	if ( hasDangerouslySetInnerHTML && requiredIndicator ) {
+		props.dangerouslySetInnerHTML.__html += '<span class="nfd-label__required">*</span>';
+	}
+
+	return hasDangerouslySetInnerHTML
+	?
+		(
+			<Component ref={ ref } className={ classNames( "nfd-label", className ) } { ...props } />
+		)
+	:
+		(
+			<Component ref={ ref } className={ classNames( "nfd-label", className ) } { ...props }>
+				{ label || children || null }
+				{ requiredIndicator && <span className="nfd-label__required">*</span> }
+			</Component>
+		)
+} );
 
 const propTypes = {
 	label: PropTypes.string,


### PR DESCRIPTION
## Proposed changes

Fix error `Can only set one of children or props.dangerouslySetInnerHTML` for label element when dangerouslySetInnerHTML is passed.

Related opened issue: https://github.com/newfold-labs/npm-ui-component-library/issues/27


## Type of Change

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
