### PR TITLE
Use built-in transition for Modal component

### DIFF
--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -1,6 +1,6 @@
-import { Dialog, DialogPanel, DialogTitle, Description, Transition, TransitionChild, DialogBackdrop } from "@headlessui/react";
+import { Dialog, DialogPanel, DialogTitle, Description, DialogBackdrop } from "@headlessui/react";
 import { XIcon } from "@heroicons/react/outline";
-import { forwardRef, Fragment } from "react";
+import { forwardRef } from "react";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import { useSvgAria } from "../../hooks";
@@ -61,7 +61,8 @@ const Panel = forwardRef( ( { children, className = "", hasCloseButton = true, c
 	return (
 		<DialogPanel
 			ref={ ref }
-			className={ classNames( "nfd-modal__panel", className ) }
+			transition
+			className={ classNames( "nfd-modal__panel nfd-transition nfd-ease-out data-[closed]:nfd-scale-95 data-[closed]:nfd-opacity-0 data-[enter]:nfd-duration-300 data-[leave]:nfd-duration-200", className ) }
 			{ ...props }
 		>
 			{ hasCloseButton && <div className="nfd-modal__close">
@@ -120,39 +121,14 @@ const Modal = forwardRef( ( { isOpen, onClose, children, className = "", positio
 			onClose={ onClose }
 			{ ...props }
 		>
-			<Transition
-				as={ Fragment }
-				show={ isOpen }
-				appear
-			>
-				<div className={ classNames( "nfd-modal", classNameMap.position[ position ], className ) }>
-					<TransitionChild
-						as={ Fragment }
-						enter="nfd-ease-out nfd-duration-300"
-						enterFrom="nfd-opacity-0"
-						enterTo="nfd-opacity-100"
-						leave="nfd-ease-in nfd-duration-200"
-						leaveFrom="nfd-opacity-100"
-						leaveTo="nfd-opacity-0"
-					>
-						<DialogBackdrop className="nfd-modal__overlay" />
-					</TransitionChild>
-
-					<TransitionChild
-						as={ Fragment }
-						enter="nfd-ease-out nfd-duration-300"
-						enterFrom="nfd-opacity-0 nfd-scale-95 nfd-translate-y-4 sm:nfd-translate-y-0 sm:nfd-scale-95"
-						enterTo="nfd-opacity-100 nfd-scale-100 nfd-translate-y-0 sm:nfd-scale-100"
-						leave="nfd-ease-in nfd-duration-200"
-						leaveFrom="nfd-opacity-100 nfd-scale-100 nfd-translate-y-0 sm:nfd-scale-100"
-						leaveTo="nfd-opacity-0 nfd-scale-95 nfd-translate-y-4 sm:nfd-translate-y-0 sm:nfd-scale-95"
-					>
-						<div className="nfd-modal__layout">
-							{ children }
-						</div>
-					</TransitionChild>
+			<div className={ classNames( "nfd-modal", classNameMap.position[ position ], className ) }>
+				<DialogBackdrop
+					transition
+					className="nfd-modal__overlay nfd-transition nfd-ease-out data-[closed]:nfd-opacity-0 data-[enter]:nfd-duration-300 data-[leave]:nfd-duration-200" />
+				<div className="nfd-modal__layout">
+					{ children }
 				</div>
-			</Transition>
+			</div>
 		</Dialog>
 	</ModalContext.Provider>
 ) );


### PR DESCRIPTION
## Proposed changes

As a follow-up to the closed PR https://github.com/newfold-labs/npm-ui-component-library/pull/65, I tested version v2 and noticed the animation issue still persists.

After reviewing the Headless UI documentation, I replaced the external `Transition` component with the built-in `transition` property provided by the `Dialog` component.

This change resolves the close animation issue and also simplifies the implementation, resulting in cleaner and more readable code.

## Before fix


https://github.com/user-attachments/assets/686a0ad1-ba88-4375-aa05-3bcaa159a04f

## After fix

https://github.com/user-attachments/assets/89195ce6-f379-4683-8159-8a31b672052b



## Type of Change

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)