### PR TITLE
Render hidden input element if name prop is passed

### DIFF
--- a/src/elements/tag-input/index.js
+++ b/src/elements/tag-input/index.js
@@ -86,9 +86,15 @@ const TagInput = forwardRef( ( {
 	...props
 }, ref ) => {
 	const [ text, setText ] = useState( "" );
+
+	// Get props name if passed and remove from props.
+	const inputName = props?.name || "";
+	delete props?.name
+
 	const handleChange = useCallback( event => {
 		isString( event?.target?.value ) && setText( event.target.value );
 	}, [ setText ] );
+
 	const handleKeyDown = useCallback( event => {
 		switch ( event.key ) {
 			case ",":
@@ -114,6 +120,7 @@ const TagInput = forwardRef( ( {
 				return true;
 		}
 	}, [ text, tags, setText, onAddTag ] );
+
 	const handleBlur = useCallback( event => {
 		if ( text.length > 0 ) {
 			onAddTag( text );
@@ -145,6 +152,7 @@ const TagInput = forwardRef( ( {
 				onBlur={ handleBlur }
 				value={ text }
 			/>
+			{inputName && <input type="hidden" readOnly name={inputName} value={JSON.stringify(tags)} /> }
 		</div>
 	);
 } );


### PR DESCRIPTION
## Proposed changes

To align with the behavior of other Headless UI inputs like [Listbox](https://headlessui.com/react/listbox#using-with-html-forms) or [Switch](https://headlessui.com/react/switch#using-with-html-forms), this PR introduces the same behaviour for `ToggleField`.

When the name prop is added to `ToggleField`, a hidden input element is rendered and kept in sync with the component state. This allows the component to be used within a native HTML form and supports traditional form submissions.


## Type of Change

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
