### PR TITLE
New PriceField component

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@newfold/ui-component-library",
   "version": "2.0.0",
   "description": "A UI component library by Newfold Digital",
-  "main": "index.js",
-  "style": "css/style.css",
+  "main": "build/index.js",
+  "style": "build/css/style.css",
   "author": {
     "name": "Newfold Labs",
     "url": "https://github.com/newfold-labs"

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@newfold/ui-component-library",
   "version": "2.0.0",
   "description": "A UI component library by Newfold Digital",
-  "main": "build/index.js",
-  "style": "build/css/style.css",
+  "main": "index.js",
+  "style": "css/style.css",
   "author": {
     "name": "Newfold Labs",
     "url": "https://github.com/newfold-labs"

--- a/src/components/price-field/index.js
+++ b/src/components/price-field/index.js
@@ -36,6 +36,7 @@ const PriceField = forwardRef( ( {
 									description,
 									validation,
 									format,
+									value,
 									...props
 								}, ref ) => {
 
@@ -80,7 +81,7 @@ const PriceField = forwardRef( ( {
 	}
 
 	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
-	const [ price, setPrice ] = useState( validatePrice( props?.value || '' ) );
+	const [ price, setPrice ] = useState( validatePrice( value ) );
 
 	return (
 		<div
@@ -147,6 +148,7 @@ const propTypes = {
 	className: PropTypes.string,
 	description: PropTypes.node,
 	icon: PropTypes.elementType,
+	value: PropTypes.string,
 	validation: PropTypes.shape( {
 		variant: PropTypes.string,
 		message: PropTypes.node,
@@ -165,10 +167,11 @@ PriceField.defaultProps = {
 	disabled: false,
 	readOnly: false,
 	required: false,
-	className: "",
+	className: '',
 	description: null,
 	icon: null,
 	validation: {},
+	value: '',
 	format: {
 		decimals: 2,
 		decimalSeparator: '.',

--- a/src/components/price-field/index.js
+++ b/src/components/price-field/index.js
@@ -39,13 +39,10 @@ const PriceField = forwardRef( ( {
 									...props
 								}, ref ) => {
 
-	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
-	const [ price, setPrice ] = useState( props?.value || '' );
-
-	const validatePrice = (e) => {
+	const validatePrice = (price) => {
 
 		let number   = parseFloat(
-				e.target.value
+				price
 					.replace( new RegExp(`[^0-9${format.decimalSeparator}]`, 'gm'), '' )
 					.replace( format.decimalSeparator, '.' )
 			),
@@ -54,7 +51,7 @@ const PriceField = forwardRef( ( {
 		if ( ! isNaN( number ) ) {
 			// Check if the original value contains the decimal separator character, and preserve it in the formatted value as well.
 			// This is because parseFloat removes it, making it impossible to enter a decimal number.
-			let hasDecimal = -1 !== e.target.value.indexOf( format.decimalSeparator );
+			let hasDecimal = -1 !== price.indexOf( format.decimalSeparator );
 
 			// Convert to string.
 			number = number + '';
@@ -69,8 +66,21 @@ const PriceField = forwardRef( ( {
 			formatted += hasDecimal ? format.decimalSeparator + decimals.slice( 0, format.decimals ) : '';
 		}
 
-		setPrice(formatted);
+		return formatted;
 	}
+
+	const handleInputChange = (e) => {
+		e.preventDefault();
+
+		setPrice( validatePrice( e.target.value ) );
+
+		if ( typeof onChange === 'function' ){
+			onChange(e);
+		}
+	}
+
+	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
+	const [ price, setPrice ] = useState( validatePrice( props?.value || '' ) );
 
 	return (
 		<div
@@ -100,7 +110,7 @@ const PriceField = forwardRef( ( {
 				ref={ ref }
 				id={ id }
 				icon={ icon }
-				onChange={ validatePrice }
+				onChange={ handleInputChange }
 				disabled={ disabled }
 				readOnly={ readOnly }
 				required={ required }

--- a/src/components/price-field/index.js
+++ b/src/components/price-field/index.js
@@ -1,0 +1,177 @@
+import { forwardRef, useState } from "react";
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import Label from "../../elements/label";
+import TextInput from "../../elements/text-input";
+import { ValidationInput, ValidationMessage } from "../../elements/validation";
+import { useDescribedBy } from "../../hooks";
+
+/**
+ * @param {string} id The ID of the input.
+ * @param {function} onChange The input change handler.
+ * @param {string} label The label.
+ * @param {JSX.node} [labelSuffix] Extra elements after the label.
+ * @param {string} [className] The HTML class.
+ * @param {JSX.node} [description] A description.
+ * @param {boolean} [disabled] The disabled state.
+ * @param {boolean} [readOnly] The read-only state.
+ * @param {boolean} [required] The required state.
+ * @param {JSX.Element} [icon] The field icon.
+ * @param {Object} [validation] The validation state.
+ * @param {Object} [format] The price format.
+ * @param {Object} [props] Any extra properties for the TextInput.
+ * @returns {JSX.Element} The input field.
+ */
+const PriceField = forwardRef( ( {
+									id,
+									onChange,
+									label,
+									labelSuffix,
+									labelRequiredIndicator,
+									disabled,
+									readOnly,
+									required,
+									icon,
+									className,
+									description,
+									validation,
+									format,
+									...props
+								}, ref ) => {
+
+	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
+	const [ price, setPrice ] = useState( props?.value || '' );
+
+	const validatePrice = (e) => {
+
+		let number   = parseFloat(
+				e.target.value
+					.replace( new RegExp(`[^0-9${format.decimalSeparator}]`, 'gm'), '' )
+					.replace( format.decimalSeparator, '.' )
+			),
+			formatted = '';
+
+		if ( ! isNaN( number ) ) {
+			// Check if the original value contains the decimal separator character, and preserve it in the formatted value as well.
+			// This is because parseFloat removes it, making it impossible to enter a decimal number.
+			let hasDecimal = -1 !== e.target.value.indexOf( format.decimalSeparator );
+
+			// Convert to string.
+			number = number + '';
+
+			let [thousands = '', decimals = ''] = number.split('.'),
+				mod = thousands.length > 3 ? thousands.length % 3 : 0;
+
+			// Format thousands.
+			formatted = (mod ? thousands.slice(0, mod) + format.thousandSeparator : '') + thousands.slice(mod).replace(/(\d{3})(?=\d)/g, "$1" + format.thousandSeparator);
+
+			// Format decimals.
+			formatted += hasDecimal ? format.decimalSeparator + decimals.slice( 0, format.decimals ) : '';
+		}
+
+		setPrice(formatted);
+	}
+
+	return (
+		<div
+			className={ classNames(
+				"nfd-price-field",
+				disabled && "nfd-price-field--disabled",
+				readOnly && "nfd-price-field--read-only",
+				icon && "nfd-price-field--with-icon",
+				className,
+			) }
+		>
+			{
+				!! label &&
+				<div className="nfd-flex nfd-items-center nfd-mb-2">
+					<Label
+						requiredIndicator={ ( required && labelRequiredIndicator ) }
+						className="nfd-price-field__label"
+						htmlFor={ id }
+					>
+						{ label }
+					</Label>
+					{ labelSuffix }
+				</div>
+			}
+			<ValidationInput
+				as={ TextInput }
+				ref={ ref }
+				id={ id }
+				icon={ icon }
+				onChange={ validatePrice }
+				disabled={ disabled }
+				readOnly={ readOnly }
+				required={ required }
+				className={ classNames(
+					"nfd-price-field__input",
+					{
+						"nfd-price-field--input-with-icon": icon,
+					},
+				) }
+				aria-describedby={ describedBy }
+				validation={ validation }
+				value={price}
+				{ ...props }
+			/>
+			{ validation?.message && (
+				<ValidationMessage variant={ validation?.variant } id={ ids.validation } className="nfd-price-field__validation">
+					{ validation.message }
+				</ValidationMessage>
+			) }
+			{ description && <p id={ ids.description } className="nfd-price-field__description">{ description }</p> }
+		</div>
+	);
+} );
+
+const propTypes = {
+	id: PropTypes.string.isRequired,
+	label: PropTypes.string.isRequired,
+	onChange: PropTypes.func,
+	labelSuffix: PropTypes.node,
+	labelRequiredIndicator: PropTypes.node,
+	disabled: PropTypes.bool,
+	readOnly: PropTypes.bool,
+	required: PropTypes.bool,
+	className: PropTypes.string,
+	description: PropTypes.node,
+	icon: PropTypes.elementType,
+	validation: PropTypes.shape( {
+		variant: PropTypes.string,
+		message: PropTypes.node,
+	} ),
+	format: PropTypes.shape( {
+		decimals: PropTypes.number,
+		decimalSeparator: PropTypes.string,
+		thousandSeparator: PropTypes.string,
+	} ),
+};
+
+PriceField.propTypes = propTypes;
+
+PriceField.defaultProps = {
+	labelSuffix: null,
+	disabled: false,
+	readOnly: false,
+	required: false,
+	className: "",
+	description: null,
+	icon: null,
+	validation: {},
+	format: {
+		decimals: 2,
+		decimalSeparator: '.',
+		thousandSeparator: '',
+	}
+};
+
+PriceField.displayName = "PriceField";
+
+// eslint-disable-next-line require-jsdoc
+export const StoryComponent = props => <PriceField { ...props } />;
+StoryComponent.propTypes = propTypes;
+StoryComponent.defaultProps = PriceField.defaultProps;
+StoryComponent.displayName = "PriceField";
+
+export default PriceField;

--- a/src/components/price-field/index.js
+++ b/src/components/price-field/index.js
@@ -39,8 +39,8 @@ const PriceField = forwardRef( ( {
 									 value,
 									 ...props
 								 }, ref ) => {
-	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
 	const [ price, setPrice ] = useState( "" );
+	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
 
 	/**
 	 * Validate and format given price

--- a/src/components/price-field/style.css
+++ b/src/components/price-field/style.css
@@ -1,0 +1,36 @@
+@layer components {
+	.nfd-root {
+		.nfd-price-field--disabled {
+			.nfd-price-field__label,
+			.nfd-price-field__description {
+				@apply nfd-opacity-50;
+			}
+
+			.nfd-price-field__label {
+				@apply nfd-cursor-not-allowed;
+			}
+		}
+
+		.nfd-price-field--read-only {
+			.nfd-price-field__label {
+				@apply nfd-cursor-default;
+			}
+		}
+
+		.nfd-price-field__description {
+			@apply nfd-mt-2;
+		}
+
+		.nfd-price-field__validation {
+			@apply nfd-mt-2;
+		}
+
+		.nfd-price-field__validation {
+			@apply nfd-mt-2;
+		}
+
+		.nfd-price-field__input.nfd-price-field--input-with-icon{
+			@apply nfd-pr-[calc(1.25rem+24px)];
+		}
+	}
+}

--- a/src/elements/text-input/style.css
+++ b/src/elements/text-input/style.css
@@ -17,20 +17,19 @@
 			focus:nfd-border-primary-500;
 		}
 
-		.nfd-text-input--disabled {
-			@apply
-			nfd-opacity-50
-			nfd-cursor-not-allowed
-			focus:nfd-ring-0;
-		}
-
-		.nfd-text-input--read-only {
+		.nfd-text-input--read-only, .nfd-text-input--disabled {
 			@apply
 			nfd-border-slate-200
 			nfd-shadow-none
 			nfd-text-slate-500
 			nfd-bg-slate-50
 			nfd-cursor-default;
+		}
+
+		.nfd-text-input--disabled {
+			@apply
+			nfd-cursor-not-allowed
+			focus:nfd-ring-0;
 		}
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ export { default as ImageImport } from "./components/image-import";
 export { default as Modal } from "./components/modal";
 export { default as Notifications } from "./components/notifications";
 export { default as Page } from "./components/page";
+export { default as PriceField } from "./components/price-field";
 export { default as RadioGroup } from "./components/radio-group";
 export { default as Root } from "./components/root";
 export { default as SelectField } from "./components/select-field";


### PR DESCRIPTION
## Proposed changes

This PR introduces a new component, `PriceField`:

- it is based on a TextInput element;
- on input change, the value is passed to a validation function that sanitizes and formats it;
- using the format prop, it is possible to customize price formatting options such as the number of decimals, decimal separator, and thousands separator.

This is an example of use:
```
<PriceField
    id="nfd-price-field"
    label="Price"
    format={{
        decimals: 2,
        decimalSeparator: '.',
        thousandSeparator: ',',
    }}
/>
```

Using this filed typing `asd1234//.34` will become `1,234.34`
A possible future improvement could be adding the currency symbol to the formatted value.

## Type of Change

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)