### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/cypress-component-tests.yml
+++ b/.github/workflows/cypress-component-tests.yml
@@ -4,12 +4,15 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   cypress-component-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo.
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/cypress-component-tests.yml
+++ b/.github/workflows/cypress-component-tests.yml
@@ -11,6 +11,7 @@ permissions: {}
 jobs:
   cypress-component-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read # Required to clone the repo.
 

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -6,12 +6,16 @@ on:
       - docs
   workflow_dispatch:
 
-permissions:
-  contents: write
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   build-and-deploy:
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to clone the repo and to push the build to the gh-pages branch via JamesIves/github-pages-deploy-action.
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -14,6 +14,7 @@ jobs:
   build-and-deploy:
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write # Required to clone the repo and to push the build to the gh-pages branch via JamesIves/github-pages-deploy-action.
     steps:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,6 +21,7 @@ jobs:
     publish:
         name: Publish Package
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         permissions: {} # Checkout authenticates with NEWFOLD_ACCESS_TOKEN (PAT) and npm publish uses NODE_AUTH_TOKEN; GITHUB_TOKEN is not used to interact with any GitHub service.
         env:
             NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,10 +13,15 @@ on:
         tags:
             - '*'
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
     publish:
         name: Publish Package
         runs-on: ubuntu-latest
+        permissions: {} # Checkout authenticates with NEWFOLD_ACCESS_TOKEN (PAT) and npm publish uses NODE_AUTH_TOKEN; GITHUB_TOKEN is not used to interact with any GitHub service.
         env:
             NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
         steps:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -21,9 +21,16 @@ on:
                     - major
                 required: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
     prepare-release:
         runs-on: ubuntu-latest
+        permissions:
+            contents: write       # Required for peter-evans/create-pull-request to push the release branch using GITHUB_TOKEN.
+            pull-requests: write  # Required for peter-evans/create-pull-request to open the pull request using GITHUB_TOKEN.
         steps:
         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
           with:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -28,6 +28,7 @@ permissions: {}
 jobs:
     prepare-release:
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         permissions:
             contents: write       # Required for peter-evans/create-pull-request to push the release branch using GITHUB_TOKEN.
             pull-requests: write  # Required for peter-evans/create-pull-request to open the pull request using GITHUB_TOKEN.


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/newfold-labs/npm-ui-component-library/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 4 (`cypress-component-tests.yml`, `docs-deploy.yml`, `npm-publish.yml`, `prepare-release.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `e8d673d` |
| Timeouts commit | `f2a0285` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `cypress-component-tests.yml` (replaced existing top-level `contents: read` with `permissions: {}` and moved scope to job level) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `docs-deploy.yml` (replaced existing top-level `contents: write` with `permissions: {}` and moved scope to job level) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `npm-publish.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `prepare-release.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| cypress-component-tests.yml | 1 job was missing a scoped `permissions:` directive | cypress-component-tests | `contents: read` [3] — required for `actions/checkout` on a private repo. `actions/upload-artifact@v7` uses the runtime artifact service (not `GITHUB_TOKEN`) and needs no scopes. |
| docs-deploy.yml | 1 job was missing a scoped `permissions:` directive | build-and-deploy | `contents: write` [3] — required for `actions/checkout` and for `JamesIves/github-pages-deploy-action` to push the build to the `gh-pages` branch using `GITHUB_TOKEN` (per the action's README). |
| npm-publish.yml | 1 job was missing a scoped `permissions:` directive | publish | `permissions: {}` [2] — `actions/checkout` authenticates with `NEWFOLD_ACCESS_TOKEN` (a PAT), `npm publish` uses `NODE_AUTH_TOKEN`, and `fregante/setup-git-user` only sets local git config. No step uses `GITHUB_TOKEN` to call GitHub services. |
| prepare-release.yml | 1 job was missing a scoped `permissions:` directive | prepare-release | `contents: write`, `pull-requests: write` [3] — `peter-evans/create-pull-request@v8` is invoked with `token: ${{ secrets.GITHUB_TOKEN }}`; per its docs it needs `contents: write` to push the branch and `pull-requests: write` to open the PR. (Checkout itself uses `NEWFOLD_ACCESS_TOKEN`, so no extra scope is needed for that step.) |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `cypress-component-tests.yml` :: workflow-level: BEFORE `contents: read` (workflow-wide) -> AFTER top-level `permissions: {}` with job-level `contents: read` on `cypress-component-tests` -- least-privilege: scope the read to the only job that needs it -- [confidence 3] |
| 2 | `docs-deploy.yml` :: workflow-level: BEFORE `contents: write` (workflow-wide) -> AFTER top-level `permissions: {}` with job-level `contents: write` on `build-and-deploy` -- least-privilege: confine write scope to the deploy job -- [confidence 3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| cypress-component-tests.yml | cypress-component-tests | `30` | Cypress browser test suites with `npm ci` and screenshot/video artifact uploads can occasionally hang on a single flaky spec, so 30 minutes gives ample headroom while still bounding runaway runs. |
| docs-deploy.yml | build-and-deploy | `15` | Small `npm ci` + `npm run build` followed by a `gh-pages` push typically finishes in a few minutes; 15 minutes is comfortable margin. |
| npm-publish.yml | publish | `15` | `npm install`, build, and `npm publish` are usually quick; 15 minutes covers slow network or registry hiccups. |
| prepare-release.yml | prepare-release | `10` | Job only checks out the repo, bumps the version, and opens a PR via `peter-evans/create-pull-request`; 10 minutes is generous for that work. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | `fregante/setup-git-user@v2.0.2` (used in `npm-publish.yml` and `prepare-release.yml`) is a small action that only sets local `git config user.name`/`user.email`. The action's source file could not be fetched directly during this audit, but its stated purpose and observed usage indicate no `GITHUB_TOKEN`-backed API calls. If it ever began making API calls it would still only need read access to public user data, so this does not change the scoped permissions above. Flagging for human awareness; no permission added on its behalf. |
| 2 | `npm-publish.yml` triggers on tag push and uses `NEWFOLD_ACCESS_TOKEN` for checkout plus `NPM_AUTH_TOKEN` for publish. The `permissions: {}` on the `publish` job is correct only as long as no future step uses the auto-provisioned `GITHUB_TOKEN` (e.g. to create a GitHub Release). If a release-creation step is added later, it will need `contents: write`. |
| 3 | Commits were created with the existing local git identity and GPG signing was used (no git config changes). Branch was created locally and intentionally not pushed. |


